### PR TITLE
Support `.skip_ci` sentinel files

### DIFF
--- a/src/commands/check_workspace/mod.rs
+++ b/src/commands/check_workspace/mod.rs
@@ -259,11 +259,7 @@ fn get_blob_name(
 }
 
 impl Result {
-    pub async fn new(
-        workspace: String,
-        package: Package,
-        root_dir: PathBuf,
-    ) -> anyhow::Result<Self> {
+    pub fn new(workspace: String, package: Package, root_dir: PathBuf) -> anyhow::Result<Self> {
         let path = package
             .manifest_path
             .canonicalize()?
@@ -781,9 +777,7 @@ pub async fn check_workspace(
                     workspace_name.to_string_lossy().to_string(),
                     package.clone(),
                     working_directory.clone(),
-                )
-                .await
-                {
+                ) {
                     Ok(package) => {
                         packages.insert(package.package.clone(), package);
                     }


### PR DESCRIPTION
I want this feature for https://github.com/ForesightMiningSoftwareCorporation/fsl_libs/pull/1438. 

It's a waste to run CI on vendored sources that already get indirect test coverage.