### PR TITLE
chore: add more logs for debugging CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.8.1"
+version = "2.8.3"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fslabscli"
-version = "2.8.2"
+version = "2.8.3"
 edition = "2021"
 authors = ["FSLABS DevOps Gods"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"

--- a/src/commands/check_workspace/mod.rs
+++ b/src/commands/check_workspace/mod.rs
@@ -1062,6 +1062,7 @@ pub async fn check_workspace(
         }
     }
     let package_keys: Vec<String> = packages.keys().cloned().collect();
+    log::info!("Package list: {package_keys:#?}");
 
     if options.progress {
         println!(
@@ -1080,10 +1081,12 @@ pub async fn check_workspace(
         // Check changed from a git pov
         let changed_package_paths =
             crates.changed_packages(&options.changed_base_ref, &options.changed_head_ref)?;
+        log::info!("Changed packages: {changed_package_paths:#?}");
         // Any packages that transitively depend on changed packages are also considered "changed".
         let changed_closure = crates
             .dependency_graph()
             .reverse_closure(changed_package_paths.iter().map(AsRef::as_ref));
+        log::info!("Changed closure: {changed_closure:#?}");
 
         for package_key in package_keys.clone() {
             if let Some(ref pb) = pb {


### PR DESCRIPTION
We are noticing that dependency graph change detection is not working in CI, so this should help us understand why.