### PR TITLE
feat: remove all optional tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.8.4"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -341,7 +341,6 @@ dependencies = [
  "serial_test",
  "strum",
  "strum_macros",
- "tempfile",
  "testcontainers",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-fslabscli"
-version = "2.8.4"
+version = "2.9.0"
 edition = "2021"
 authors = ["FSLABS DevOps Gods"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
@@ -51,7 +51,6 @@ chrono = "0.4"
 rust-toolchain-file = "0.1"
 futures-util = "0.3.30"
 humanize-duration = { version = "0.0.6", features = ["chrono"]}
-tempfile = "3.10.1"
 zip = "2.1.5"
 bytes = "1.6.1"
 junit-report = "0.8.3"


### PR DESCRIPTION
Remove optional tests that just add noise to our PR testing, we can restore these once they pass and we commit to maintaining them.  Personally I'm a fan of the `cargo deny` check for duplicate dependencies

It is worth checking `cargo deny` advisories, it had some recommendations of version bumps for security warnings in fsl_libs.