### PR TITLE
Async Comand Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,134 +1,133 @@
+[package]
+authors = ["FSLABS DevOps Gods"]
+description = "Command line interface for helping FSLABS ci"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+name = "cargo-fslabscli"
+publish = ["foresight-mining-software-corporation"]
+repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
+version = "2.10.0"
 
-[dependencies]
-  base64 = "0.21"
-  bytes = "1.10.0"
-  cargo_metadata = "0.19.1"
-  chrono = "0.4"
-  console = "0.15.10"
-  convert_case = "0.7.1"
-  exitcode = "1.1"
-  futures-util = "0.3.31"
-  http = "1.2.0"
-  http-body-util = "0.1"
-  ignore = "0.4.23"
-  indicatif = "0.17.11"
-  itertools = "0.12"
-  jsonwebtoken = "9.3.1"
-  junit-report = "0.8.3"
-  log = "0.4"
-  log4rs = "1.3"
-  num = "0.4.3"
-  octocrab = "0.39"
-  port_check = "0.2.1"
-  rand = "0.9.0"
-  rust-toolchain-file = "0.1"
-  serde_json = "1.0"
-  serde_yaml = "0.9.34+deprecated"
-  strum = "0.26"
-  strum_macros = "0.26"
-  toml = "0.8.20"
-  url = "2.5.4"
-  void = "1.0.2"
-  zip = "2.2.2"
+[package.metadata]
 
-  [dependencies.anyhow]
-    features = []
-    version = "1.0.96"
+[package.metadata.fslabs]
 
-  [dependencies.clap]
-    features = ["derive", "env"]
-    version = "4.5.30"
+[package.metadata.fslabs.publish]
 
-  [dependencies.git2]
-    default-features = false
-    version = "0.20.0"
-
-  [dependencies.humanize-duration]
-    features = ["chrono"]
-    version = "0.0.6"
-
-  [dependencies.hyper]
-    default-features = false
-    version = "1"
-
-  [dependencies.hyper-rustls]
-    version = "0.26"
-
-  [dependencies.hyper-util]
-    default-features = false
-    features = ["tokio", "client-legacy"]
-    version = "0.1"
-
-  [dependencies.indexmap]
-    features = ["serde"]
-    version = "2.2"
-
-  [dependencies.object_store]
-    features = ["azure"]
-    version = "0.11.2"
-
-  [dependencies.oci-distribution]
-    default-features = false
-    features = ["rustls-tls"]
-    version = "0.11.0"
-
-  [dependencies.quick-xml]
-    features = ["serialize"]
-    version = "0.37.2"
-
-  [dependencies.reqwest]
-    default-features = false
-    features = ["rustls-tls"]
-    version = "0.12"
-
-  [dependencies.rustls]
-    default-features = false
-    features = ["tls12"]
-    version = "0.22"
-
-  [dependencies.serde]
-    features = ["derive", "std"]
-    version = "1.0"
-
-  [dependencies.serde_with]
-    features = ["macros"]
-    version = "3.6"
-
-  [dependencies.tokio]
-    features = ["full"]
-    version = "1.43.0"
-
-[dev-dependencies]
-  assert_fs = "1.1.2"
-  indoc = "2.0"
-  serial_test = "3.2.0"
-  testcontainers = "0.15"
-  wiremock = "0.6"
+[package.metadata.fslabs.publish.binary]
+name = "FSLABS Cli tool"
+publish = true
+sign = false
+targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-  alpha = []
-  beta = []
-  nightly = []
-  prod = []
+alpha = []
+beta = []
+nightly = []
+prod = []
 
-[package]
-  authors = ["FSLABS DevOps Gods"]
-  description = "Command line interface for helping FSLABS ci"
-  edition = "2021"
-  license = "MIT OR Apache-2.0"
-  name = "cargo-fslabscli"
-  publish = ["foresight-mining-software-corporation"]
-  repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-  version = "2.9.3"
+[dependencies]
+base64 = "0.21"
+bytes = "1.10.0"
+cargo_metadata = "0.19.1"
+chrono = "0.4"
+console = "0.15.10"
+convert_case = "0.7.1"
+exitcode = "1.1"
+futures-util = "0.3.31"
+http = "1.2.0"
+http-body-util = "0.1"
+ignore = "0.4.23"
+indicatif = "0.17.11"
+itertools = "0.12"
+jsonwebtoken = "9.3.1"
+junit-report = "0.8.3"
+log = "0.4"
+log4rs = "1.3"
+num = "0.4.3"
+octocrab = "0.39"
+port_check = "0.2.1"
+rand = "0.9.0"
+rust-toolchain-file = "0.1"
+serde_json = "1.0"
+serde_yaml = "0.9.34+deprecated"
+strum = "0.26"
+strum_macros = "0.26"
+toml = "0.8.20"
+url = "2.5.4"
+void = "1.0.2"
+zip = "2.2.2"
 
-  [package.metadata]
+[dependencies.anyhow]
+features = []
+version = "1.0.96"
 
-    [package.metadata.fslabs]
+[dependencies.clap]
+features = ["derive", "env"]
+version = "4.5.30"
 
-      [package.metadata.fslabs.publish]
+[dependencies.git2]
+default-features = false
+version = "0.20.0"
 
-        [package.metadata.fslabs.publish.binary]
-          name = "FSLABS Cli tool"
-          publish = true
-          sign = false
-          targets = ["x86_64-unknown-linux-gnu"]
+[dependencies.humanize-duration]
+features = ["chrono"]
+version = "0.0.6"
+
+[dependencies.hyper]
+default-features = false
+version = "1"
+
+[dependencies.hyper-rustls]
+version = "0.26"
+
+[dependencies.hyper-util]
+default-features = false
+features = ["tokio", "client-legacy"]
+version = "0.1"
+
+[dependencies.indexmap]
+features = ["serde"]
+version = "2.2"
+
+[dependencies.object_store]
+features = ["azure"]
+version = "0.11.2"
+
+[dependencies.oci-distribution]
+default-features = false
+features = ["rustls-tls"]
+version = "0.11.0"
+
+[dependencies.quick-xml]
+features = ["serialize"]
+version = "0.37.2"
+
+[dependencies.reqwest]
+default-features = false
+features = ["rustls-tls"]
+version = "0.12"
+
+[dependencies.rustls]
+default-features = false
+features = ["tls12"]
+version = "0.22"
+
+[dependencies.serde]
+features = ["derive", "std"]
+version = "1.0"
+
+[dependencies.serde_with]
+features = ["macros"]
+version = "3.6"
+
+[dependencies.tokio]
+features = ["full"]
+version = "1.43.0"
+
+[dev-dependencies]
+assert_fs = "1.1.2"
+indoc = "2.0"
+serial_test = "3.2.0"
+testcontainers = "0.15"
+wiremock = "0.6"

--- a/src/commands/rust_tests/mod.rs
+++ b/src/commands/rust_tests/mod.rs
@@ -385,20 +385,22 @@ pub async fn rust_tests(options: Box<Options>, repo_root: PathBuf) -> anyhow::Re
                 ..Default::default()
             },
             FslabsTest {
-                command: format!("cargo check --all-targets {additional_args}"),
+                command: format!("cargo check --all-targets --color=always {additional_args}"),
                 ..Default::default()
             },
             FslabsTest {
-                command: format!("cargo clippy --all-targets {additional_args} -- -D warnings"),
+                command: format!(
+                    "cargo clippy --all-targets --color=always {additional_args} -- -D warnings"
+                ),
                 ..Default::default()
             },
             FslabsTest {
-                command: "cargo doc --no-deps".to_string(),
+                command: "cargo doc --no-deps --color=always".to_string(),
                 envs: HashMap::from([("RUSTDOCFLAGS".to_string(), "-D warnings".to_string())]),
                 ..Default::default()
             },
             FslabsTest {
-                command: format!("cargo test --all-targets {additional_args}"),
+                command: format!("cargo test --all-targets --color=always {additional_args}"),
                 pre_command: database_url
                     .clone()
                     .map(|d| format!("echo DATABASE_URL={d} > .env")),

--- a/src/commands/rust_tests/mod.rs
+++ b/src/commands/rust_tests/mod.rs
@@ -125,7 +125,6 @@ async fn execute_command(
     }
 
     let status = child.wait().await;
-    println!("Command exited with: {:?}", status);
 
     match status {
         Ok(output) => {

--- a/src/commands/rust_tests/mod.rs
+++ b/src/commands/rust_tests/mod.rs
@@ -12,6 +12,7 @@ use std::{
     fmt::{Display, Formatter},
     fs::File,
     path::PathBuf,
+    process::Stdio,
     thread::sleep,
     time::Duration,
 };
@@ -92,6 +93,8 @@ async fn execute_command(
         .arg(command)
         .current_dir(dir)
         .envs(envs)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .expect("Unable to spawn command");
 
@@ -424,7 +427,7 @@ pub async fn rust_tests(options: Box<Options>, repo_root: PathBuf) -> anyhow::Re
                     &package_path,
                     &fslabs_test.envs,
                     Some(log::Level::Debug),
-                    Some(log::Level::Error),
+                    Some(log::Level::Debug),
                 )
                 .await;
                 if let Some(post_command) = fslabs_test.post_command {

--- a/src/commands/rust_tests/mod.rs
+++ b/src/commands/rust_tests/mod.rs
@@ -384,22 +384,20 @@ pub async fn rust_tests(options: Box<Options>, repo_root: PathBuf) -> anyhow::Re
                 ..Default::default()
             },
             FslabsTest {
-                command: format!("cargo check --all-targets --color=always {additional_args}"),
+                command: format!("cargo check --all-targets {additional_args}"),
                 ..Default::default()
             },
             FslabsTest {
-                command: format!(
-                    "cargo clippy --all-targets --color=always {additional_args} -- -D warnings"
-                ),
+                command: format!("cargo clippy --all-targets {additional_args} -- -D warnings"),
                 ..Default::default()
             },
             FslabsTest {
-                command: "cargo doc --no-deps --color=always".to_string(),
+                command: "cargo doc --no-deps".to_string(),
                 envs: HashMap::from([("RUSTDOCFLAGS".to_string(), "-D warnings".to_string())]),
                 ..Default::default()
             },
             FslabsTest {
-                command: format!("cargo test --all-targets --color=always {additional_args}"),
+                command: format!("cargo test --all-targets {additional_args}"),
                 pre_command: database_url
                     .clone()
                     .map(|d| format!("echo DATABASE_URL={d} > .env")),


### PR DESCRIPTION
Adds the ability to emit logs during command execution.

We are seeing some cases where the rust tests appear to hang. Because commands only emit the result after the command completes, we have no idea where the command is hanging, as  the command never completes.

This new functionality is only enabled for rust tests, which were already emitting debug logs of the results.