### PR TITLE
Prettification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["foresight-mining-software-corporation"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.10.0"
+version = "2.10.1"
 
 [package.metadata]
 


### PR DESCRIPTION
```
2025-02-25 06:37:47 - INFO: Detected change in "."
2025-02-25 06:37:47 - INFO: Testing . - cargo-fslabscli - 2.10.0
2025-02-25 06:37:47 - INFO: 
2025-02-25 06:37:47 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:37:47 - INFO: │ cargo fmt --verbose -- --check                     ⋯ │
2025-02-25 06:37:47 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:37:47 - INFO:   ╰───────⏵ PASS ✔ in 132ms746µs
2025-02-25 06:37:47 - INFO: 
2025-02-25 06:37:47 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:37:47 - INFO: │ cargo check --all-targets                          ⋯ │
2025-02-25 06:37:47 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:37:50 - INFO:   ╰───────⏵ PASS ✔ in 2s785ms65µs
2025-02-25 06:37:50 - INFO: 
2025-02-25 06:37:50 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:37:50 - INFO: │ cargo clippy --all-targets  -- -D warnings         ⋯ │
2025-02-25 06:37:50 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:37:52 - INFO:   ╰───────⏵ PASS ✔ in 2s140ms953µs
2025-02-25 06:37:52 - INFO: 
2025-02-25 06:37:52 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:37:52 - INFO: │ cargo doc --no-deps                                ⋯ │
2025-02-25 06:37:52 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:37:54 - INFO:   ╰───────⏵ PASS ✔ in 1s964ms175µs
2025-02-25 06:37:54 - INFO: 
2025-02-25 06:37:54 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:37:54 - INFO: │ cargo test --all-targets                           ⋯ │
2025-02-25 06:37:54 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:37:58 - INFO:   ╰───────⏵ PASS ✔ in 3s776ms197µs
2025-02-25 06:37:58 - INFO: 
2025-02-25 06:37:58 - INFO: Workspace tests ran in 11s442ms320µs
```

With `-vvv`

```
2025-02-25 06:41:02 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:41:02 - INFO: │ cargo fmt --verbose -- --check                     ⋯ │
2025-02-25 06:41:02 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:41:03 - DEBUG:  │ [bin (2021)] "/Users/aevyrieroessler/code/fslabscli/src/main.rs"
2025-02-25 06:41:03 - DEBUG:  │ rustfmt --edition 2021 --check /Users/aevyrieroessler/code/fslabscli/src/main.rs
2025-02-25 06:41:03 - INFO:   ╰───────⏵ PASS ✔ in 126ms605µs
2025-02-25 06:41:03 - INFO: 
2025-02-25 06:41:03 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:41:03 - INFO: │ cargo check --all-targets                          ⋯ │
2025-02-25 06:41:03 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:41:03 - DEBUG:  │ warning: version requirement `0.9.34+deprecated` for dependency `serde_yaml` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
2025-02-25 06:41:03 - DEBUG:  │    Compiling ring v0.17.9
2025-02-25 06:41:03 - DEBUG:  │    Compiling rustls v0.23.23
2025-02-25 06:41:03 - DEBUG:  │    Compiling rustls v0.22.4
2025-02-25 06:41:03 - DEBUG:  │     Checking rustls-webpki v0.102.8
2025-02-25 06:41:03 - DEBUG:  │     Checking jsonwebtoken v9.3.1
2025-02-25 06:41:04 - DEBUG:  │     Checking tokio-rustls v0.26.1
2025-02-25 06:41:04 - DEBUG:  │     Checking hyper-rustls v0.27.5
2025-02-25 06:41:04 - DEBUG:  │     Checking tokio-rustls v0.25.0
2025-02-25 06:41:04 - DEBUG:  │     Checking reqwest v0.12.12
2025-02-25 06:41:04 - DEBUG:  │     Checking hyper-rustls v0.26.0
2025-02-25 06:41:04 - DEBUG:  │     Checking octocrab v0.39.0
2025-02-25 06:41:04 - DEBUG:  │     Checking oci-distribution v0.11.0
2025-02-25 06:41:04 - DEBUG:  │     Checking object_store v0.11.2
2025-02-25 06:41:04 - DEBUG:  │     Checking cargo-fslabscli v2.10.1 (/Users/aevyrieroessler/code/fslabscli)
2025-02-25 06:41:05 - DEBUG:  │     Finished `dev` profile [unoptimized] target(s) in 2.74s
2025-02-25 06:41:05 - INFO:   ╰───────⏵ PASS ✔ in 2s786ms793µs
2025-02-25 06:41:05 - INFO: 
2025-02-25 06:41:05 - INFO: ╭──────────────────────────────────────────────────────╮
2025-02-25 06:41:05 - INFO: │ cargo clippy --all-targets  -- -D warnings         ⋯ │
2025-02-25 06:41:05 - INFO: ╰─┬────────────────────────────────────────────────────╯
2025-02-25 06:41:05 - DEBUG:  │ warning: version requirement `0.9.34+deprecated` for dependency `serde_yaml` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
2025-02-25 06:41:06 - DEBUG:  │     Checking cargo-fslabscli v2.10.1 (/Users/aevyrieroessler/code/fslabscli)
2025-02-25 06:41:07 - DEBUG:  │     Finished `dev` profile [unoptimized] target(s) in 2.04s
2025-02-25 06:41:08 - INFO:   ╰───────⏵ PASS ✔ in 2s121ms488µs
2025-02-25 06:41:08 - INFO: 
```