### PR TITLE
Lp/publish alt registries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.15.0"
+version = "2.16.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -399,6 +399,7 @@ dependencies = [
  "port_check",
  "quick-xml 0.37.2",
  "rand 0.9.0",
+ "regex",
  "rust-toolchain-file",
  "rustls 0.22.4",
  "serde",
@@ -412,6 +413,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "toml_edit 0.22.24",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["foresight-mining-software-corporation", "fslabs-nominal"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.15.0"
+version = "2.16.0"
 
 [package.metadata]
 
@@ -78,6 +78,8 @@ toml = "0.8.20"
 unicode-width = "0.2.0"
 clap_complete = "4.5.46"
 clap_mangen = "0.2.26"
+regex = "1.11.1"
+toml_edit = "0.22.24"
 
 [dependencies.anyhow]
 features = []

--- a/flake.lock
+++ b/flake.lock
@@ -387,6 +387,7 @@
         "gitignore": "gitignore_2",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs_7",
+        "rust-overlay": "rust-overlay",
         "treefmt-nix": "treefmt-nix"
       }
     },
@@ -404,6 +405,26 @@
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741919466,
+        "narHash": "sha256-xto0Oq+WItjDZvafo6ZVI4TZa6/2oxJHb0tkcSGVUJI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8b137260b776525542d47d3a4dbac753df478a42",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     },

--- a/src/commands/check_workspace/mod.rs
+++ b/src/commands/check_workspace/mod.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, prelude::*};
+use chrono::{prelude::*, Duration};
 use core::result::Result as CoreResult;
 use std::cmp;
 use std::cmp::Ordering;
@@ -12,11 +12,11 @@ use std::time::Instant;
 use anyhow::Context;
 use cargo_metadata::{DependencyKind, Package, PackageId};
 use clap::Parser;
-use console::{Emoji, style};
+use console::{style, Emoji};
 use futures_util::StreamExt;
 use indexmap::IndexMap;
 use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
-use object_store::{ObjectStore, path::Path as BSPath};
+use object_store::{path::Path as BSPath, ObjectStore};
 use rust_toolchain_file::toml::Parser as ToolchainParser;
 use serde::ser::{Serialize as SerSerialize, SerializeStruct, Serializer as SerSerializer};
 use serde::{Deserialize, Serialize, Serializer};
@@ -781,7 +781,11 @@ impl Display for Results {
 }
 
 fn bool_to_emoji(value: bool) -> &'static str {
-    if value { "x" } else { "" }
+    if value {
+        "x"
+    } else {
+        ""
+    }
 }
 impl PrettyPrintable for Results {
     fn pretty_print(&self) -> String {
@@ -866,7 +870,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Resolving workspaces...",
-            style("[1/10]").bold().dim(),
+            style("[1/7]").bold().dim(),
             LOOKING_GLASS
         );
     }
@@ -882,7 +886,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Resolving packages...",
-            style("[2/10]").bold().dim(),
+            style("[2/7]").bold().dim(),
             TRUCK
         );
     }
@@ -925,7 +929,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Compute runtime information...",
-            style("[3/10]").bold().dim(),
+            style("[3/7]").bold().dim(),
             TRUCK
         );
     }
@@ -965,7 +969,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Back-feeding alt registry settings...",
-            style("[4/10]").bold().dim(),
+            style("[4/7]").bold().dim(),
             PAPER
         );
     }
@@ -1017,7 +1021,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Checking published status...",
-            style("[4/10]").bold().dim(),
+            style("[5/7]").bold().dim(),
             PAPER
         );
     }
@@ -1117,7 +1121,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Resolving packages dependencies...",
-            style("[3/10]").bold().dim(),
+            style("[6/7]").bold().dim(),
             TRUCK
         );
     }
@@ -1161,7 +1165,7 @@ pub async fn check_workspace(
     if options.progress {
         println!(
             "{} {}Checking if packages changed...",
-            style("[8/10]").bold().dim(),
+            style("[7/7]").bold().dim(),
             TRUCK
         );
     }
@@ -1230,8 +1234,8 @@ mod tests {
     use git2::Repository;
 
     use crate::{
-        commands::check_workspace::{Options, Result as Package, check_workspace},
-        utils::test::{FAKE_REGISTRY, commit_all_changes, initialize_workspace},
+        commands::check_workspace::{check_workspace, Options, Result as Package},
+        utils::test::{commit_all_changes, initialize_workspace, FAKE_REGISTRY},
     };
 
     fn create_complex_workspace() -> PathBuf {

--- a/src/crate_graph.rs
+++ b/src/crate_graph.rs
@@ -1,7 +1,7 @@
 use cargo_metadata::{
-    DependencyKind, Metadata, MetadataCommand, Package, PackageId, semver::Version,
+    semver::Version, DependencyKind, Metadata, MetadataCommand, Package, PackageId,
 };
-use git2::{DiffDelta, Repository, build::CheckoutBuilder};
+use git2::{build::CheckoutBuilder, DiffDelta, Repository};
 use ignore::gitignore::Gitignore;
 use std::{
     borrow::Cow,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use indexmap::IndexMap;
 use serde::de::{Error as SerdeError, MapAccess, Visitor};
-use serde::{de, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de};
 use std::{collections::HashMap, fmt::Display, path::PathBuf, process::Stdio};
 use tokio::io::AsyncBufReadExt;
 
@@ -12,6 +12,8 @@ use void::Void;
 
 pub mod cargo;
 pub mod github;
+#[cfg(test)]
+pub mod test;
 
 pub trait FromMap {
     fn from_map(map: IndexMap<String, String>) -> Result<Self, Void>

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{File, OpenOptions, create_dir_all},
+    fs::{create_dir_all, File, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
     process::Command,

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -1,0 +1,142 @@
+use std::{
+    fs::{File, OpenOptions, create_dir_all},
+    io::Write,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use git2::Repository;
+
+pub fn commit_all_changes(repo_path: &PathBuf, message: &str) {
+    stage_all(repo_path);
+    commit_repo(repo_path, message);
+}
+
+pub fn modify_file(repo_path: &Path, file_path: &str, content: &str) {
+    let full_path = repo_path.join(file_path);
+
+    // Ensure the directory exists
+    create_dir_all(full_path.parent().unwrap()).expect("Failed to create directories");
+
+    // Modify the file
+    std::fs::write(&full_path, content).expect("Failed to write to file");
+}
+
+pub fn stage_file(repo_path: &PathBuf, file_path: &str) {
+    let repo = Repository::open(repo_path).expect("Failed to open repo");
+    let mut index = repo.index().unwrap();
+    index
+        .add_all([file_path].iter(), git2::IndexAddOption::DEFAULT, None)
+        .expect("Failed to add files to index");
+    index.write().expect("Failed to write index");
+}
+
+pub fn stage_all(repo_path: &PathBuf) {
+    stage_file(repo_path, "*");
+}
+
+pub fn commit_repo(repo_path: &PathBuf, commit_message: &str) {
+    let repo = Repository::open(repo_path).expect("Failed to open repo");
+    let mut index = repo.index().unwrap();
+
+    let oid = index.write_tree().unwrap();
+    let signature = repo.signature().unwrap();
+    let tree = repo.find_tree(oid).unwrap();
+    let parent_commit = repo
+        .head()
+        .ok()
+        .and_then(|r| r.target())
+        .and_then(|oid| repo.find_commit(oid).ok());
+
+    if let Some(parent) = parent_commit {
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            commit_message,
+            &tree,
+            &[&parent],
+        )
+        .unwrap();
+    } else {
+        repo.commit(
+            Some("HEAD"),
+            &signature,
+            &signature,
+            commit_message,
+            &tree,
+            &[],
+        )
+        .unwrap();
+    };
+}
+
+pub static FAKE_REGISTRY: &str = "fake-registry";
+
+pub fn initialize_workspace(
+    base_path: &Path,
+    workspace_name: &str,
+    sub_crates: Vec<&str>,
+    alt_registries: Vec<&str>,
+) {
+    // Create lib.rs and Cargo.toml
+    let workspace_dir = base_path.join(workspace_name);
+    create_dir_all(&workspace_dir).unwrap();
+    Command::new("cargo")
+        .arg("init")
+        .arg("--lib")
+        .arg("--name")
+        .arg(workspace_name)
+        .arg("--registry")
+        .arg(FAKE_REGISTRY)
+        .current_dir(&workspace_dir)
+        .output()
+        .expect("Failed to create simple crate");
+
+    let config_toml_dir = base_path.join(".cargo");
+    create_dir_all(&config_toml_dir).unwrap();
+    let config_toml = config_toml_dir.join("config.toml");
+    let config_toml_content = format!(
+        "[registries.{}]\nindex = \"ssh://git@ssh.shipyard.rs/{}/crate-index.git\"",
+        FAKE_REGISTRY, FAKE_REGISTRY
+    );
+    let mut file = File::create(config_toml).unwrap();
+    writeln!(file, "{}", config_toml_content).unwrap();
+
+    if !alt_registries.is_empty() {
+        // Set Alternate registry for crates_g
+        let cargo_toml = workspace_dir.join("Cargo.toml");
+        let toml_content = format!(
+            "{}\nalternate_registries=[\"{}\"]",
+            r#"
+[package.metadata.fslabs.publish.cargo]
+publish = true
+"#,
+            alt_registries.join("\", \"")
+        );
+        let mut file = OpenOptions::new().append(true).open(cargo_toml).unwrap();
+        writeln!(file, "{}", toml_content).unwrap();
+    }
+
+    if !sub_crates.is_empty() {
+        let cargo_toml = base_path.join(workspace_name).join("Cargo.toml");
+        let toml_content = "\n[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"".to_string();
+        let mut file = OpenOptions::new().append(true).open(cargo_toml).unwrap();
+        writeln!(file, "{}", toml_content).unwrap();
+        let sub_crates_dir = base_path.join(workspace_name).join("crates");
+        for sub_crate in sub_crates {
+            let sub_crate_dir = sub_crates_dir.join(sub_crate);
+            create_dir_all(&sub_crate_dir).unwrap();
+            Command::new("cargo")
+                .arg("init")
+                .arg("--lib")
+                .arg("--name")
+                .arg(format!("{}__{}", workspace_name, sub_crate))
+                .arg("--registry")
+                .arg(FAKE_REGISTRY)
+                .current_dir(&sub_crate_dir)
+                .output()
+                .expect("Failed to create simple crate");
+        }
+    }
+}


### PR DESCRIPTION
fixes #101 

In order to publish a package to an alternate registry, one needs to add this registry to the `Cargo.toml` file like this:
```Cargo.toml #
[package.metadata.fslabs.publish.cargo]
publish = true
alternate_registries =  ["alternate_registry"]
```

By doing so, the publishing will:
- Backfeed this settings to any dependencies
- At publish time:
  - Overwrite the `package.publish` settings to accept the alt registry.
  - Overwrite the `registry` field of any dependency to this alt registry.

This means that the following `Cargo.toml` would be updated for each registry before publishing
```diff #
[package]
name = "tld_pack"
version = "15.0.0"
edition = "2021"
- publish = ["foresight-mining-software-corporation"]
+ publish = ["alternate_registry"]
license = "ForesightPermissiveLicense"

[package.metadata.fslabs.publish.cargo]
publish = true
alternate_registries =  ["alternate_registry"]

[dependencies]
- sld = { version = "0.9", registry = "foresight-mining-software-corporation" }
+ sld = { version = "0.9", registry = "alternate_registry" }

``` 

 
## Env var setup
In order for this to work, you need to have the following env var setup when publishing
- `CARGO_REGISTRIES_FSLABS_NOMINAL_CRATE_URL`: Used to look information on existing crates (e.g. `https://shipyard.rs/api/v1/shipyard/krates/by-name/`, ``)
- `CARGO_REGISTRIES_FSLABS_NOMINAL_USER_AGENT`: Some registry requests a user agent (e.g `shipyard RG9uJ3QgVHJ5IHRvIExvb2sgTWUgVXAsIHlvdSBzbmVha3kgY3VyaW91cyBjaGFwCg==`
- `CARGO_REGISTRIES_FSLABS_NOMINAL_TOKEN`: Your registry auth token (e.g `"RG9uJ3QgVHJ5IHRvIExvb2sgTWUgVXAsIHlvdSBzbmVha3kgY3VyaW91cyBjaGFwCg==`)
- `CARGO_REGISTRIES_FSLABS_NOMINAL_INDEX`: Registry index url (e.g. `ssh://git@ssh.shipyard.rs/alternate_registry/crate-index.git`
- `CARGO_REGISTRIES_FSLABS_NOMINAL_PRIVATE_KEY`: Private Key Path for the registry 

