### PR TITLE
restore metrics temporality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.18.3"
+version = "2.18.4"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["fsl"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.18.3"
+version = "2.18.4"
 
 [package.metadata]
 
@@ -79,7 +79,9 @@ clap_mangen = "0.2.26"
 regex = "1.11.1"
 toml_edit = "0.22.24"
 walkdir = "2.5.0"
-self_update = { version = "0.42.0", default-features = false, features = ["rustls"] }
+self_update = { version = "0.42.0", default-features = false, features = [
+    "rustls",
+] }
 tempfile = "3.19"
 cargo-util = "0.2"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_sdk::{
     Resource,
     logs::SdkLoggerProvider,
-    metrics::{MeterProviderBuilder, SdkMeterProvider, Temporality},
+    metrics::{MeterProviderBuilder, SdkMeterProvider},
     trace::SdkTracerProvider,
 };
 use serde::Serialize;
@@ -129,7 +129,6 @@ fn get_resource(with_unique_attributes: bool) -> Resource {
 fn init_metrics(with_unique_attributes: bool) -> SdkMeterProvider {
     let exporter = opentelemetry_otlp::MetricExporter::builder()
         .with_tonic()
-        .with_temporality(Temporality::Delta)
         .build()
         .unwrap();
 


### PR DESCRIPTION
- since #132 metrics aren't reported anymore
- revert the temporality of the reporter back to the default