### PR TITLE
tests on different crates can be executed in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.18.4"
+version = "2.18.5"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 publish = ["fsl"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.18.4"
+version = "2.18.5"
 
 [package.metadata]
 


### PR DESCRIPTION
while testing a single PR, tests on different crates can be executed in parallel. This can risk over committing the cores, and consuming too much memory, so we also need to be able to limit the number of cores each task will use.

two new env variables:
- `JOB_LIMIT`: number of crates that can be tested in parallel. defaults to 1
- `INNER_JOB_LIMIT`: number of cores that can be taken to run tests on a crate. defaults to 0 meaning unlimited

Test will fail fast, so first failure will stop all threads

logs have been modified to be more clear in a multithreaded context:
```
[...]
│ bevy_mikktspace                5/5 | cargo test --all-targets  --jobs 5                 │ ► START
│ build-easefunction-graphs      4/5 | cargo doc --no-deps --jobs 5                       │ 🟢 PASS in 5s
│ build-easefunction-graphs      5/5 | cargo test --all-targets  --jobs 5                 │ ► START
│ bevy_app                       4/5 | cargo doc --no-deps --jobs 5                       │ 🟢 PASS in 9s
│ bevy_app                       5/5 | cargo test --all-targets  --jobs 5                 │ ► START
│ bevy_text                      4/5 | cargo doc --no-deps --jobs 5                       │ 🟢 PASS in 10s
│ bevy_text                      5/5 | cargo test --all-targets  --jobs 5                 │ ► START
│ bevy_core_pipeline             4/5 | cargo doc --no-deps --jobs 5                       │ 🟢 PASS in 8s
│ bevy_core_pipeline             5/5 | cargo test --all-targets  --jobs 5                 │ ► START
│ bevy_mikktspace                5/5 | cargo test --all-targets  --jobs 5                 │ 🟢 PASS in 9s
Testing . - bevy_utils - 0.16.0-rc.3
│ bevy_utils                     1/5 | cargo fmt --verbose -- --check                     │ ► START
│ bevy_utils                     1/5 | cargo fmt --verbose -- --check                     │ 🟢 PASS in 0s
│ bevy_utils                     2/5 | cargo check --all-targets  --jobs 5                │ ► START
│ bevy_render_macros             5/5 | cargo test --all-targets  --jobs 5                 │ 🟢 PASS in 12s
Testing . - no_std_library - 0.1.0
│ no_std_library                 1/5 | cargo fmt --verbose -- --check                     │ ► START
│ no_std_library                 1/5 | cargo fmt --verbose -- --check                     │ 🟢 PASS in 0s
│ no_std_library                 2/5 | cargo check --all-targets  --jobs 5                │ ► START
│ build-easefunction-graphs      5/5 | cargo test --all-targets  --jobs 5                 │ 🟢 PASS in 12s
Testing . - bevy_transform - 0.16.0-rc.3
│ bevy_transform                 1/5 | cargo fmt --verbose -- --check                     │ ► START
│ bevy_transform                 1/5 | cargo fmt --verbose -- --check                     │ 🟢 PASS in 0s
│ bevy_transform                 2/5 | cargo check --all-targets  --jobs 5                │ ► START
│ bevy_pbr                       4/5 | cargo doc --no-deps --jobs 5                       │ 🟥 FAIL in 18s
│ bevy_pbr                       5/5 | cargo test --all-targets  --jobs 5                 │ ⏭ SKIPPED
Testing . - ci - 0.0.0
│ ci                             1/5 | cargo fmt --verbose -- --check                     │ ► START
Workspace tests ran in 27s687ms485µs
```