### PR TITLE
disable colors in logs on commands

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -239,7 +239,7 @@ pub async fn execute_command(
     // disable colors in log to get clean strings
     c.env("NO_COLOR", "true");
 
-    let mut child = c.spawn().expect("Unmable to spawn command");
+    let mut child = c.spawn().expect("Unable to spawn command");
 
     let stdout = child.stdout.take().expect("Failed to get stdout");
     let mut stdout_stream = tokio::io::BufReader::new(stdout).lines();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -236,6 +236,8 @@ pub async fn execute_command(
         c.env_remove(env);
     }
     c.envs(envs);
+    // disable colors in log to get clean strings
+    c.env("NO_COLOR", "true");
 
     let mut child = c.spawn().expect("Unmable to spawn command");
 


### PR DESCRIPTION
some Junit files are not parsed correctly by prow, making it fail to display the reports

The ANSI color codes in logs may make some xml parser fail, remove them using [`NO_COLOR`](https://no-color.org)