### PR TITLE
deps(cargo): bump all policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,15 +1616,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1974,19 +1965,22 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+checksum = "e9ce831b09395f933addbc56d894d889e4b226eba304d4e7adbab591e26daf1e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "form_urlencoded",
  "futures",
+ "http",
+ "http-body-util",
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.37.4",
@@ -1995,7 +1989,8 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "snafu",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3969,7 +3969,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -3969,7 +3969,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3969,7 +3969,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,7 +3969,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3969,7 +3969,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "serde",
@@ -383,7 +383,7 @@ dependencies = [
  "hyper-rustls 0.26.0",
  "hyper-util",
  "ignore",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "indicatif",
  "indoc",
  "itertools 0.12.1",
@@ -398,7 +398,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "port_check",
- "quick-xml 0.37.3",
+ "quick-xml 0.37.4",
  "rand 0.9.0",
  "regex",
  "rust-toolchain-file",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "932c5376dc904ef005f0d229a5edc1116f40a78a18d30cdc992ec5acbeffd4d9"
+checksum = "527f6e2a4e80492e90628052be879a5996c2453ad5ec745bfa310a80b7eca20a"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.0",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "jobserver",
  "libc",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -805,9 +805,9 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -895,9 +895,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1139,7 +1139,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1546,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1640,10 +1640,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -1748,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1830,9 +1831,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1988,7 +1989,7 @@ dependencies = [
  "itertools 0.13.0",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.37.3",
+ "quick-xml 0.37.4",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -2370,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.3"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf763ab1c7a3aa408be466efc86efe35ed1bd3dd74173ed39d6b0d0a6f0ba148"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
 dependencies = [
  "memchr",
  "serde",
@@ -2509,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -2654,9 +2655,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -2874,7 +2875,7 @@ dependencies = [
  "hyper",
  "indicatif",
  "log",
- "quick-xml 0.37.3",
+ "quick-xml 0.37.4",
  "regex",
  "reqwest",
  "self-replace",
@@ -2976,7 +2977,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3014,7 +3015,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -3127,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "snafu"
@@ -3400,9 +3401,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3499,7 +3500,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3512,11 +3513,11 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.4",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -4284,9 +4285,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -4454,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "aes",
  "arbitrary",
@@ -4468,7 +4469,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.2",
  "hmac",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,9 +1242,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humanize-duration"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082247a9fa508369fe52b235aef8a8dbf931b08d223a1a9b70cd400a8a77ae9c"
+checksum = "9d17650201754d4f79437bc2fa1f157273a7779de1391c818b275d6bb40998b9"
 dependencies = [
  "chrono",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@
 
   [dependencies.quick-xml]
     features = ["serialize"]
-    version = "0.37.2"
+    version = "0.37.4"
 
   [dependencies.rustls]
     default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@
 
   [dependencies.object_store]
     features = ["azure"]
-    version = "0.11.2"
+    version = "0.12.0"
 
   [dependencies.oci-distribution]
     default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,155 +1,170 @@
-[package]
-authors = ["FSLABS DevOps Gods"]
-description = "Command line interface for helping FSLABS ci"
-edition = "2024"
-license = "MIT OR Apache-2.0"
-name = "cargo-fslabscli"
-publish = ["fsl"]
-repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.18.7"
-
-[package.metadata]
-
-[package.metadata.fslabs]
-
-[package.metadata.fslabs.publish]
-
-[package.metadata.fslabs.publish.binary]
-name = "FSLABS Cli tool"
-publish = true
-sign = false
-targets = ["x86_64-unknown-linux-gnu"]
-[package.metadata.fslabs.publish.nix_binary]
-publish = true
-
-
-[features]
-alpha = []
-beta = []
-nightly = []
-prod = []
 
 [dependencies]
-base64 = "0.21"
-bytes = "1.10.1"
-cargo_metadata = "0.19.2"
-chrono = "0.4"
-console = "0.15.11"
-convert_case = "0.8.0"
-dunce = "1.0.5"
-exitcode = "1.1"
-futures-util = "0.3.31"
-http = "1.2.0"
-http-body-util = "0.1"
-ignore = "0.4.23"
-indicatif = "0.17.11"
-itertools = "0.12"
-jsonwebtoken = "9.3.1"
-junit-report = "0.8.3"
-num = "0.4.3"
-octocrab = "0.39"
-opentelemetry-appender-tracing = { version = "0.28" }
-opentelemetry_sdk = { version = "0.28", features = ["logs"] }
-opentelemetry-otlp = { version = "0.28", features = ["logs", "grpc-tonic"] }
-opentelemetry = { version = "0.28" }
-port_check = "0.2.1"
-rand = "0.9.0"
-rust-toolchain-file = "0.1"
-serde_json = "1.0"
-serde_yaml = "0.9.34+deprecated"
-strum = "0.27.1"
-strum_macros = "0.27.1"
-tracing = { version = "0.1", features = ["std"] }
-tracing-subscriber = { version = "0.3", features = [
-    "std",
-    "env-filter",
-    "fmt",
-] }
-url = "2.5.4"
-void = "1.0.2"
-zip = "2.2.3"
-tracing-core = "0.1.33"
-futures = "0.3.31"
-tokio-stream = "0.1.17"
-async-stream = "0.3.6"
-toml = "0.8.20"
-unicode-width = "0.2.0"
-clap_complete = "4.5.46"
-clap_mangen = "0.2.26"
-regex = "1.11.1"
-toml_edit = "0.22.24"
-walkdir = "2.5.0"
-self_update = { version = "0.42.0", default-features = false, features = [
-    "rustls",
-] }
-tempfile = "3.19"
-cargo-util = "0.2"
+  async-stream = "0.3.6"
+  base64 = "0.21"
+  bytes = "1.10.1"
+  cargo-util = "0.2"
+  cargo_metadata = "0.19.2"
+  chrono = "0.4"
+  clap_complete = "4.5.46"
+  clap_mangen = "0.2.26"
+  console = "0.15.11"
+  convert_case = "0.8.0"
+  dunce = "1.0.5"
+  exitcode = "1.1"
+  futures = "0.3.31"
+  futures-util = "0.3.31"
+  http = "1.2.0"
+  http-body-util = "0.1"
+  ignore = "0.4.23"
+  indicatif = "0.17.11"
+  itertools = "0.12"
+  jsonwebtoken = "9.3.1"
+  junit-report = "0.8.3"
+  num = "0.4.3"
+  octocrab = "0.39"
+  port_check = "0.2.1"
+  rand = "0.9.0"
+  regex = "1.11.1"
+  rust-toolchain-file = "0.1"
+  serde_json = "1.0"
+  serde_yaml = "0.9.34+deprecated"
+  strum = "0.27.1"
+  strum_macros = "0.27.1"
+  tempfile = "3.19"
+  tokio-stream = "0.1.17"
+  toml = "0.8.20"
+  toml_edit = "0.22.24"
+  tracing-core = "0.1.33"
+  unicode-width = "0.2.0"
+  url = "2.5.4"
+  void = "1.0.2"
+  walkdir = "2.5.0"
+  zip = "2.2.3"
 
-[dependencies.anyhow]
-features = []
-version = "1.0.97"
+  [dependencies.anyhow]
+    features = []
+    version = "1.0.97"
 
-[dependencies.clap]
-features = ["derive", "env"]
-version = "4.5.31"
+  [dependencies.clap]
+    features = ["derive", "env"]
+    version = "4.5.35"
 
-[dependencies.git2]
-default-features = false
-version = "0.20.0"
+  [dependencies.git2]
+    default-features = false
+    version = "0.20.0"
 
-[dependencies.humanize-duration]
-features = ["chrono"]
-version = "0.0.6"
+  [dependencies.humanize-duration]
+    features = ["chrono"]
+    version = "0.0.6"
 
-[dependencies.hyper]
-default-features = false
-version = "1"
+  [dependencies.hyper]
+    default-features = false
+    version = "1"
 
-[dependencies.hyper-rustls]
-version = "0.26"
+  [dependencies.hyper-rustls]
+    version = "0.26"
 
-[dependencies.hyper-util]
-default-features = false
-features = ["tokio", "client-legacy"]
-version = "0.1"
+  [dependencies.hyper-util]
+    default-features = false
+    features = ["tokio", "client-legacy"]
+    version = "0.1"
 
-[dependencies.indexmap]
-features = ["serde"]
-version = "2.2"
+  [dependencies.indexmap]
+    features = ["serde"]
+    version = "2.2"
 
-[dependencies.object_store]
-features = ["azure"]
-version = "0.11.2"
+  [dependencies.object_store]
+    features = ["azure"]
+    version = "0.11.2"
 
-[dependencies.oci-distribution]
-default-features = false
-features = ["rustls-tls"]
-version = "0.11.0"
+  [dependencies.oci-distribution]
+    default-features = false
+    features = ["rustls-tls"]
+    version = "0.11.0"
 
-[dependencies.quick-xml]
-features = ["serialize"]
-version = "0.37.2"
+  [dependencies.opentelemetry]
+    version = "0.28"
 
-[dependencies.rustls]
-default-features = false
-features = ["tls12"]
-version = "0.22"
+  [dependencies.opentelemetry-appender-tracing]
+    version = "0.28"
 
-[dependencies.serde]
-features = ["derive", "std"]
-version = "1.0"
+  [dependencies.opentelemetry-otlp]
+    features = ["logs", "grpc-tonic"]
+    version = "0.28"
 
-[dependencies.serde_with]
-features = ["macros"]
-version = "3.6"
+  [dependencies.opentelemetry_sdk]
+    features = ["logs"]
+    version = "0.28"
 
-[dependencies.tokio]
-features = ["full"]
-version = "1.43.0"
+  [dependencies.quick-xml]
+    features = ["serialize"]
+    version = "0.37.2"
+
+  [dependencies.rustls]
+    default-features = false
+    features = ["tls12"]
+    version = "0.22"
+
+  [dependencies.self_update]
+    default-features = false
+    features = ["rustls"]
+    version = "0.42.0"
+
+  [dependencies.serde]
+    features = ["derive", "std"]
+    version = "1.0"
+
+  [dependencies.serde_with]
+    features = ["macros"]
+    version = "3.6"
+
+  [dependencies.tokio]
+    features = ["full"]
+    version = "1.43.0"
+
+  [dependencies.tracing]
+    features = ["std"]
+    version = "0.1"
+
+  [dependencies.tracing-subscriber]
+    features = ["std", "env-filter", "fmt"]
+    version = "0.3"
 
 [dev-dependencies]
-assert_fs = "1.1.2"
-indoc = "2.0"
-serial_test = "3.2.0"
-testcontainers = "0.15"
-wiremock = "0.6"
+  assert_fs = "1.1.2"
+  indoc = "2.0"
+  serial_test = "3.2.0"
+  testcontainers = "0.15"
+  wiremock = "0.6"
+
+[features]
+  alpha = []
+  beta = []
+  nightly = []
+  prod = []
+
+[package]
+  authors = ["FSLABS DevOps Gods"]
+  description = "Command line interface for helping FSLABS ci"
+  edition = "2024"
+  license = "MIT OR Apache-2.0"
+  name = "cargo-fslabscli"
+  publish = ["fsl"]
+  repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
+  version = "2.18.7"
+
+  [package.metadata]
+
+    [package.metadata.fslabs]
+
+      [package.metadata.fslabs.publish]
+
+        [package.metadata.fslabs.publish.binary]
+          name = "FSLABS Cli tool"
+          publish = true
+          sign = false
+          targets = ["x86_64-unknown-linux-gnu"]
+
+        [package.metadata.fslabs.publish.nix_binary]
+          publish = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
   cargo-util = "0.2"
   cargo_metadata = "0.19.2"
   chrono = "0.4"
-  clap_complete = "4.5.46"
+  clap_complete = "4.5.47"
   clap_mangen = "0.2.26"
   console = "0.15.11"
   convert_case = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
   exitcode = "1.1"
   futures = "0.3.31"
   futures-util = "0.3.31"
-  http = "1.2.0"
+  http = "1.3.1"
   http-body-util = "0.1"
   ignore = "0.4.23"
   indicatif = "0.17.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@
   url = "2.5.4"
   void = "1.0.2"
   walkdir = "2.5.0"
-  zip = "2.2.3"
+  zip = "2.6.1"
 
   [dependencies.anyhow]
     features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@
 
   [dependencies.humanize-duration]
     features = ["chrono"]
-    version = "0.0.6"
+    version = "0.0.7"
 
   [dependencies.hyper]
     default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@
 
   [dependencies.git2]
     default-features = false
-    version = "0.20.0"
+    version = "0.20.1"
 
   [dependencies.humanize-duration]
     features = ["chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@
 
   [dependencies.tokio]
     features = ["full"]
-    version = "1.43.0"
+    version = "1.44.2"
 
   [dependencies.tracing]
     features = ["std"]


### PR DESCRIPTION



<Actions>
    <action id="235235f457010dd45e4c69ce12e7d9761b1e9adf859351a03b71d68c3da0a3f7">
        <h3>deps(cargo): bump dependencies &#34;tempfile&#34; for &#34;cargo-fslabscli&#34; crate</h3>
        <details id="dd23e2b08749a43ccea9d445e57f8b9a9c989d11a1a03bcff4280743c8393abc">
            <summary>deps(cargo): bump crate dependency &#34;tempfile&#34; to 3.19.1</summary>
            <p>ran shell command &#34;cargo update --manifest-path Cargo.toml --package tempfile@3.19 --precise 3.19.1&#34;</p>
        </details>
    </action>
    <action id="399ea47eb9c6fad97b3da5c69f3faa0bcc4d9e9d38ed2d7e885cbcd25bc2bc99">
        <h3>deps(cargo): bump dependencies &#34;hyper&#34; for &#34;cargo-fslabscli&#34; crate</h3>
        <details id="91e235e3f8168853b4d98e751a959bd6efb933ba9362b01c7595964648b8bbbf">
            <summary>deps(cargo): bump crate dependency &#34;hyper&#34; to 1.6.0</summary>
            <p>ran shell command &#34;cargo update --manifest-path Cargo.toml --package hyper@1 --precise 1.6.0&#34;</p>
        </details>
    </action>
    <action id="7a23c6e1007d32028fc806493daf47011dee7236a7d21dac1c3c6bb4ce36c6d6">
        <h3>deps(cargo): bump dev-dependencies &#34;wiremock&#34; for &#34;cargo-fslabscli&#34; crate</h3>
        <details id="bc0a6c32e867b582ea8d00e265e43a24aa4e13e0aa96620f5c30a5386a872a93">
            <summary>deps(cargo): bump crate dependency &#34;wiremock&#34; to 0.6.3</summary>
            <p>ran shell command &#34;cargo update --manifest-path Cargo.toml --package wiremock@0.6 --precise 0.6.3&#34;</p>
        </details>
    </action>
    <action id="8104cb3c3e7aafd0485e66b848cf0c6902e56619261f6d8527032616c68dcd9f">
        <h3>deps(cargo): bump dependencies &#34;cargo-util&#34; for &#34;cargo-fslabscli&#34; crate</h3>
        <details id="345087ed49736bf6bd5ca3fcb700400e1b46356262a61f9a59caaa456fb7bbe5">
            <summary>deps(cargo): bump crate dependency &#34;cargo-util&#34; to 0.2.19</summary>
            <p>ran shell command &#34;cargo update --manifest-path Cargo.toml --package cargo-util@0.2 --precise 0.2.19&#34;</p>
        </details>
    </action>
    <action id="9320f153c653bc7ab0f89cb9d8552d3d13882d7d8a6bfaba9dd4e089d0a4b106">
        <h3>deps(cargo): bump dependencies &#34;opentelemetry-otlp&#34; for &#34;cargo-fslabscli&#34; crate</h3>
        <details id="e45a96289c973a9a2bdf16a70843d20855776ffef489f5ec12cc32dc20e9e44b">
            <summary>deps(cargo): bump crate dependency &#34;opentelemetry-otlp&#34; to 0.28.0</summary>
            <p>ran shell command &#34;cargo update --manifest-path Cargo.toml --package opentelemetry-otlp@0.28 --precise 0.28.0&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

