### PR TITLE
fix: cache_miss_command should be ran from repo_root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.22.2"
+version = "2.22.3"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 # publish = ["fsl"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.22.2"
+version = "2.22.3"
 
 [package.metadata]
 

--- a/src/commands/tests/mod.rs
+++ b/src/commands/tests/mod.rs
@@ -399,7 +399,7 @@ async fn do_test_on_package(
             }
             let (stdout, stderr, success) = execute_command_without_logging(
                 &cache_miss_command,
-                &package_path,
+                &repo_root,
                 &envs,
                 &HashSet::new(),
             )


### PR DESCRIPTION
Back in the rust test bash script we used to run the cache miss before the `pushd`:

https://github.com/ForesightMiningSoftwareCorporation/fslabs-infrastructure/blob/780e742676fe5251ca41722a2f7d051848d1a259/images/prow-tests/rust_test.sh#L223-L232

https://github.com/ForesightMiningSoftwareCorporation/fslabs-infrastructure/blob/780e742676fe5251ca41722a2f7d051848d1a259/images/prow-tests/rust_test.sh#L249

hence running the cache_miss in the repo_root