### PR TITLE
Only check envs once

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -296,7 +296,7 @@ pub async fn execute_command(
 
 pub fn get_env_or_log(env_name: String) -> Result<String, VarError> {
     std::env::var(&env_name).map_err(|e| {
-        info!("Failed to load env `{}` {}", env_name, e);
+        warn!("Failed to load env `{}` {}", env_name, e);
         e
     })
 }


### PR DESCRIPTION
Right now the tool checks for environment variables for every invocation of `CrateGraph::new_recursiveg, but this check can be done once before the call to `new_recursive`. It only depends on `main_registry` which is was only passed recursively for this.

This PR is useful because when running locally it currently spams the console with a bunch of logs of missing env variables.