### PR TITLE
 Lp/fix dep tree publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.28.0"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 # publish = ["fsl"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.28.0"
+version = "2.29.0"
 
 [package.metadata]
 

--- a/src/commands/check_workspace/mod.rs
+++ b/src/commands/check_workspace/mod.rs
@@ -169,6 +169,11 @@ impl Options {
         self
     }
 
+    pub fn with_autopublish_cargo(mut self, autopublish_cargo: bool) -> Self {
+        self.autopublish_cargo = autopublish_cargo;
+        self
+    }
+
     pub fn with_ignore_dev_dependencies(mut self, ignore_dev_dependencies: bool) -> Self {
         self.ignore_dev_dependencies = ignore_dev_dependencies;
         self

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1274,7 +1274,7 @@ pub async fn publish(
                 .get(member_id)
                 .map(|deps| {
                     // We should remove the dev and path only dependencies from the tree
-                    deps.into_iter()
+                    deps.iter()
                         .filter(|d| {
                             d.instances
                                 .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,12 +67,12 @@ struct Cli {
 pub struct PackageRelatedOptions {
     #[clap(
         long,
-        env = "PULL_PULL_SHA",
+        env = "PULL_PULL_REF",
         default_value = "HEAD",
-        alias = "pull-pull-sha"
+        alias = "pull-pull-ref"
     )]
     head_rev: String,
-    #[clap(long, env = "PULL_BASE_SHA", alias = "pull-base-sha")]
+    #[clap(long, env = "PULL_BASE_REF", alias = "pull-base-ref")]
     base_rev: Option<String>,
     #[arg(long, env, default_value = "1")]
     job_limit: usize,


### PR DESCRIPTION
When generating the publishing dependencies, the dev one should be ignored