### PR TITLE
fix: convert git ref to tag to handle binary publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-fslabscli"
-version = "2.29.1"
+version = "2.29.2"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-fslabscli"
 # publish = ["fsl"]
 repository = "https://github.com/ForesightMiningSoftwareCorporation/fslabsci"
-version = "2.29.1"
+version = "2.29.2"
 
 [package.metadata]
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748883665,
-        "narHash": "sha256-R0W7uAg+BLoHjMRMQ8+oiSbTq8nkGz5RDpQ+ZfxxP3A=",
+        "lastModified": 1752264895,
+        "narHash": "sha256-1zBPE/PNAkPNUsOWFET4J0cjlvziH8DOekesDmjND+w=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "f707778d902af4d62d8dd92c269f8e70de09acbe",
+        "rev": "47053aef762f452e816e44eb9a23fbc3827b241a",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1756705356,
-        "narHash": "sha256-dpBFe8SqYKr7W6KN5QOVCr8N76SBKwTslzjw+4BVBVs=",
+        "lastModified": 1758758545,
+        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "305707bbc27d83aa1039378e91d7dd816f4cac10",
+        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
         "type": "github"
       },
       "original": {
@@ -51,16 +51,17 @@
       "inputs": {
         "cachix": "cachix",
         "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1756732270,
-        "narHash": "sha256-CV4w+73s6HBJ+0U6QSmV44NDiY5Az/5XsV+lqrsWLIY=",
+        "lastModified": 1759339967,
+        "narHash": "sha256-mMJgOCRHKDAAsU9AmgK1gV0iWMZo1yHH243uCnQ3tr4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1d5c772e984c5e29935ca3fa6b09f888dae04215",
+        "rev": "e7a45ed5e94dd286bce2a3b0f037fb4355e1ebdf",
         "type": "github"
       },
       "original": {
@@ -75,11 +76,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1756709111,
-        "narHash": "sha256-xv2u5dnQpdWkrIy5TBSomr055odWtRSoECSGBzNpp3w=",
+        "lastModified": 1759301100,
+        "narHash": "sha256-hmiTEoVAqLnn80UkreCNunnRKPucKvcg5T4/CELEtbw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "113eba389317407992ea219d5aaced44bf6407f9",
+        "rev": "0956bc5d1df2ea800010172c6bc4470d9a22cb81",
         "type": "github"
       },
       "original": {
@@ -108,16 +109,15 @@
       "inputs": {
         "nixpkgs-lib": [
           "devenv",
-          "nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
-        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "lastModified": 1758108966,
+        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
         "type": "github"
       },
       "original": {
@@ -216,7 +216,10 @@
           "devenv",
           "flake-compat"
         ],
-        "flake-parts": "flake-parts",
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
         "git-hooks-nix": [
           "devenv",
           "git-hooks"
@@ -233,27 +236,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1755029779,
-        "narHash": "sha256-3+GHIYGg4U9XKUN4rg473frIVNn8YD06bjwxKS1IPrU=",
+        "lastModified": 1758763079,
+        "narHash": "sha256-Bx1A+lShhOWwMuy3uDzZQvYiBKBFcKwy6G6NEohhv6A=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "b0972b0eee6726081d10b1199f54de6d2917f861",
+        "rev": "6f0140527c2b0346df4afad7497baa08decb929f",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.30",
+        "ref": "devenv-2.30.5",
         "repo": "nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750441195,
-        "narHash": "sha256-yke+pm+MdgRb6c0dPt8MgDhv7fcBbdjmv1ZceNTyzKg=",
+        "lastModified": 1758532697,
+        "narHash": "sha256-bhop0bR3u7DCw9/PtLCwr7GwEWDlBSxHp+eVQhCW9t4=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "0ceffe312871b443929ff3006960d29b120dc627",
+        "rev": "207a4cb0e1253c7658c6736becc6eb9cace1f25f",
         "type": "github"
       },
       "original": {
@@ -265,11 +268,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
         "type": "github"
       },
       "original": {
@@ -295,11 +298,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
         "type": "github"
       },
       "original": {
@@ -322,11 +325,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1756597274,
-        "narHash": "sha256-wfaKRKsEVQDB7pQtAt04vRgFphkVscGRpSx3wG1l50E=",
+        "lastModified": 1759245522,
+        "narHash": "sha256-H4Hx/EuMJ9qi1WzPV4UG2bbZiDCdREtrtDvYcHr0kmk=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "21614ed2d3279a9aa1f15c88d293e65a98991b30",
+        "rev": "a6bc4a4bbe6a65b71cbf76a0cf528c47a8d9f97f",
         "type": "github"
       },
       "original": {

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -81,6 +81,10 @@ pub struct Options {
     handle_tags: bool,
     #[arg(long, default_value_t = false)]
     autopublish_cargo: bool,
+    /// Pattern for matching release tags (e.g., "v*" or "cargo-fslabscli-*")
+    /// Used to filter which tags are considered for GitHub release lookup
+    #[arg(long, env, default_value = "v*")]
+    tag_pattern: String,
 }
 
 #[derive(Serialize, Default, Clone)]
@@ -1130,10 +1134,57 @@ pub async fn login(options: &Options, repo_root: &PathBuf) -> anyhow::Result<()>
     Ok(())
 }
 
+/// Resolves a commit SHA (or git reference) to a git tag name.
+/// This is used to find the GitHub release tag associated with a commit.
+/// Uses git2's describe functionality for efficient exact-match tag lookup.
+/// Filters tags by the provided pattern (e.g., "v*" or "cargo-fslabscli-*")
+fn resolve_commit_to_tag(
+    repo_root: &PathBuf,
+    commit_ref: &str,
+    tag_pattern: &str,
+) -> anyhow::Result<String> {
+    let repo = Repository::open(repo_root)
+        .with_context(|| format!("Failed to open git repository at {:?}", repo_root))?;
+
+    // Resolve the reference to a commit
+    let obj = repo
+        .revparse_single(commit_ref)
+        .with_context(|| format!("Failed to resolve git reference: {}", commit_ref))?;
+
+    // Use git2's describe with exact match option
+    let mut describe_options = git2::DescribeOptions::new();
+    describe_options
+        .describe_tags()
+        .show_commit_oid_as_fallback(false)
+        .pattern(tag_pattern);
+
+    let describe_result = obj
+        .describe(&describe_options)
+        .with_context(|| {
+            format!(
+                "No tag matching pattern '{}' found for commit {}",
+                tag_pattern,
+                commit_ref
+            )
+        })?;
+
+    // Format without any suffix (just the tag name)
+    let mut format_options = git2::DescribeFormatOptions::new();
+    format_options.abbreviated_size(0);
+
+    let tag = describe_result
+        .format(Some(&format_options))
+        .with_context(|| "Failed to format describe result")?;
+
+    tracing::debug!("Resolved {} to tag: {}", commit_ref, tag);
+    Ok(tag)
+}
+
 pub async fn report_publish_to_github(
     common_options: &PackageRelatedOptions,
     options: &Options,
     artifact_dir: &PathBuf,
+    repo_root: &PathBuf,
 ) -> anyhow::Result<()> {
     if let (Some(github_app_id), Some(github_app_private_key)) = (
         options.github_app_id,
@@ -1148,12 +1199,20 @@ pub async fn report_publish_to_github(
         .await?;
         let octocrab = Octocrab::builder().personal_token(github_token).build()?;
 
+        // Resolve the base_rev (commit SHA) to a git tag using the configured pattern
+        let base_rev = common_options.base_rev.as_deref().unwrap_or("HEAD~");
+        let release_tag = resolve_commit_to_tag(repo_root, base_rev, &options.tag_pattern)?;
+
+        tracing::info!(
+            "Resolved commit {} to tag: {} (pattern: {})",
+            base_rev,
+            release_tag,
+            options.tag_pattern
+        );
+
         let repo = octocrab.repos(&options.repo_owner, &options.repo_name);
         let repo_releases = repo.releases();
-        if let Ok(release) = repo_releases
-            .get_by_tag(common_options.base_rev.as_deref().unwrap_or("HEAD~"))
-            .await
-        {
+        if let Ok(release) = repo_releases.get_by_tag(&release_tag).await {
             let paths = fs::read_dir(artifact_dir)?;
             for artifact in paths.flatten() {
                 let artifact_path = artifact.path();
@@ -1295,7 +1354,7 @@ pub async fn publish(
     futures::future::join_all(handles).await;
 
     // Report publish result to github
-    report_publish_to_github(common_options, options, &artifact_dir)
+    report_publish_to_github(common_options, options, &artifact_dir, &repo_root)
         .await
         .with_context(|| "Issue reporting to GitHub")?;
 
@@ -1317,4 +1376,340 @@ pub async fn publish(
     // Craft Junit Results
     r.craft_junit(&options.artifacts)?;
     Ok(r)
+}
+
+#[cfg(test)]
+mod tests {
+    use git2::{Repository, Signature};
+    use std::path::PathBuf;
+
+    use super::resolve_commit_to_tag;
+    use crate::utils::test::{commit_all_changes, modify_file};
+
+    /// Helper function to create a test git repository with initial commit
+    fn create_test_repo() -> (assert_fs::TempDir, PathBuf) {
+        let temp_dir = assert_fs::TempDir::new().expect("Failed to create temp directory");
+        let repo_path = temp_dir.path().to_path_buf();
+
+        let repo = Repository::init(&repo_path).expect("Failed to init repository");
+
+        // Configure Git user info (required for commits)
+        repo.config()
+            .unwrap()
+            .set_str("user.name", "Test User")
+            .unwrap();
+        repo.config()
+            .unwrap()
+            .set_str("user.email", "test@example.com")
+            .unwrap();
+
+        // Create initial file and commit
+        modify_file(&repo_path, "README.md", "# Test Repository");
+        commit_all_changes(&repo_path, "Initial commit");
+
+        (temp_dir, repo_path)
+    }
+
+    /// Helper function to create a commit in the repository
+    fn create_commit(repo_path: &PathBuf, message: &str) -> git2::Oid {
+        // Modify a file to have something to commit
+        modify_file(repo_path, "test.txt", &format!("Content for {}", message));
+        commit_all_changes(repo_path, message);
+
+        // Get the commit OID
+        let repo = Repository::open(repo_path).expect("Failed to open repository");
+        repo.head()
+            .expect("Failed to get HEAD")
+            .target()
+            .expect("HEAD has no target")
+    }
+
+    /// Helper function to create a lightweight tag pointing to a commit
+    fn create_tag(repo_path: &PathBuf, tag_name: &str, commit_oid: git2::Oid) {
+        let repo = Repository::open(repo_path).expect("Failed to open repository");
+        let commit = repo.find_commit(commit_oid).expect("Failed to find commit");
+        let obj = commit.as_object();
+
+        repo.tag_lightweight(tag_name, obj, false)
+            .expect("Failed to create tag");
+    }
+
+    #[test]
+    fn test_resolve_commit_with_cargo_fslabscli_tag() {
+        // Test: A commit with cargo-fslabscli-* tag (project's actual format)
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Add feature");
+        create_tag(&repo_path, "cargo-fslabscli-2.29.1", commit_oid);
+
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "cargo-fslabscli-*");
+        assert!(result.is_ok(), "Should successfully resolve to tag");
+        assert_eq!(result.unwrap(), "cargo-fslabscli-2.29.1");
+    }
+
+    #[test]
+    fn test_resolve_commit_with_version_tag() {
+        // Test: A commit with a version tag (v-prefixed) should return that tag
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Add feature");
+        create_tag(&repo_path, "v2.29.1", commit_oid);
+
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_ok(), "Should successfully resolve to tag");
+        assert_eq!(result.unwrap(), "v2.29.1");
+    }
+
+    #[test]
+    fn test_resolve_commit_with_multiple_tags_filters_by_pattern() {
+        // Test: When multiple tags exist, pattern matching filters correctly
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Release commit");
+
+        // Create tags with different patterns
+        create_tag(&repo_path, "latest", commit_oid);
+        create_tag(&repo_path, "release-1.0.0", commit_oid);
+        create_tag(&repo_path, "v1.0.0", commit_oid);
+        create_tag(&repo_path, "stable", commit_oid);
+
+        // Should find only v-prefixed tag when pattern is "v*"
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_ok(), "Should successfully resolve to tag");
+        assert_eq!(result.unwrap(), "v1.0.0", "Should return v-prefixed tag");
+    }
+
+    #[test]
+    fn test_resolve_commit_filters_by_exact_pattern() {
+        // Test: Pattern matching is exact - only matches the specified pattern
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Release commit");
+
+        // Create both tag formats
+        create_tag(&repo_path, "v2.0.0", commit_oid);
+        create_tag(&repo_path, "cargo-fslabscli-2.29.1", commit_oid);
+
+        // When searching for "v*", should only return v-prefixed tag
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_ok(), "Should successfully resolve to tag");
+        assert_eq!(result.unwrap(), "v2.0.0", "Should return only v-prefixed tag");
+
+        // When searching for "cargo-fslabscli-*", should only return that tag
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "cargo-fslabscli-*");
+        assert!(result.is_ok(), "Should successfully resolve to tag");
+        assert_eq!(result.unwrap(), "cargo-fslabscli-2.29.1");
+    }
+
+    #[test]
+    fn test_resolve_commit_with_pattern_mismatch_returns_error() {
+        // Test: When no tags match the pattern, should return error
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Tagged commit");
+
+        create_tag(&repo_path, "latest", commit_oid);
+        create_tag(&repo_path, "stable", commit_oid);
+
+        // Try to find v* tags when only "latest" and "stable" exist
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_err(), "Should return error when no tags match pattern");
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("No tag matching pattern"),
+            "Error message should mention pattern mismatch, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_resolve_commit_with_no_tags_returns_error() {
+        // Test: A commit with no tags should return an error
+        let (_temp_dir, repo_path) = create_test_repo();
+        create_commit(&repo_path, "Untagged commit");
+
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_err(), "Should return error for untagged commit");
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("No tag matching pattern"),
+            "Error message should mention no tags matching pattern, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_resolve_invalid_commit_reference_returns_error() {
+        // Test: An invalid reference should return an error
+        let (_temp_dir, repo_path) = create_test_repo();
+
+        let result = resolve_commit_to_tag(&repo_path, "nonexistent-ref", "v*");
+        assert!(result.is_err(), "Should return error for invalid reference");
+
+        let err_msg = result.unwrap_err().to_string();
+        // Should contain error about resolving the reference
+        assert!(
+            err_msg.contains("Failed to resolve git reference"),
+            "Error message should indicate failure, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_resolve_commit_sha_directly() {
+        // Test: Should be able to resolve using a commit SHA directly
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Feature commit");
+        create_tag(&repo_path, "v3.0.0", commit_oid);
+
+        let commit_sha = commit_oid.to_string();
+        let result = resolve_commit_to_tag(&repo_path, &commit_sha, "v*");
+        assert!(result.is_ok(), "Should resolve commit SHA to tag");
+        assert_eq!(result.unwrap(), "v3.0.0");
+    }
+
+    #[test]
+    fn test_resolve_commit_sha_short_form() {
+        // Test: Should be able to resolve using a short commit SHA
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Short SHA test");
+        create_tag(&repo_path, "v4.0.0", commit_oid);
+
+        let commit_sha = commit_oid.to_string();
+        let short_sha = &commit_sha[..7]; // Use first 7 characters
+        let result = resolve_commit_to_tag(&repo_path, short_sha, "v*");
+        assert!(result.is_ok(), "Should resolve short commit SHA to tag");
+        assert_eq!(result.unwrap(), "v4.0.0");
+    }
+
+    #[test]
+    fn test_resolve_head_reference() {
+        // Test: Should resolve HEAD reference to tag
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "HEAD commit");
+        create_tag(&repo_path, "v5.0.0", commit_oid);
+
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_ok(), "Should resolve HEAD to tag");
+        assert_eq!(result.unwrap(), "v5.0.0");
+    }
+
+    #[test]
+    fn test_resolve_branch_reference() {
+        // Test: Should resolve a branch reference to tag
+        let (_temp_dir, repo_path) = create_test_repo();
+        let repo = Repository::open(&repo_path).expect("Failed to open repository");
+
+        // Create a commit and tag it
+        let commit_oid = create_commit(&repo_path, "Branch commit");
+        create_tag(&repo_path, "v6.0.0", commit_oid);
+
+        // Create a branch pointing to this commit
+        let commit = repo.find_commit(commit_oid).expect("Failed to find commit");
+        repo.branch("feature-branch", &commit, false)
+            .expect("Failed to create branch");
+
+        let result = resolve_commit_to_tag(&repo_path, "feature-branch", "v*");
+        assert!(result.is_ok(), "Should resolve branch reference to tag");
+        assert_eq!(result.unwrap(), "v6.0.0");
+    }
+
+    #[test]
+    fn test_resolve_older_commit_with_tag() {
+        // Test: Should resolve to tag on an older commit (not HEAD)
+        let (_temp_dir, repo_path) = create_test_repo();
+
+        // Create first commit with tag
+        let first_commit_oid = create_commit(&repo_path, "First release");
+        create_tag(&repo_path, "v1.0.0", first_commit_oid);
+
+        // Create second commit (HEAD) without tag
+        create_commit(&repo_path, "Second commit");
+
+        // Should still be able to resolve the first commit by its SHA
+        let commit_sha = first_commit_oid.to_string();
+        let result = resolve_commit_to_tag(&repo_path, &commit_sha, "v*");
+        assert!(result.is_ok(), "Should resolve older commit to tag");
+        assert_eq!(result.unwrap(), "v1.0.0");
+    }
+
+    #[test]
+    fn test_multiple_version_tags_returns_matching_tag() {
+        // Test: When multiple v-prefixed tags exist, returns one that matches the pattern
+        // Note: git describe doesn't guarantee which tag when multiple match the same commit
+        let (_temp_dir, repo_path) = create_test_repo();
+        let commit_oid = create_commit(&repo_path, "Multi-version commit");
+
+        // Create multiple tags
+        create_tag(&repo_path, "v1.0.0", commit_oid);
+        create_tag(&repo_path, "v2.0.0", commit_oid);
+        create_tag(&repo_path, "v1.0.1", commit_oid);
+
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_ok(), "Should successfully resolve to tag");
+
+        // Should return one of the v-prefixed tags
+        let tag = result.unwrap();
+        assert!(
+            tag.starts_with("v"),
+            "Should return a v-prefixed tag, got: {}",
+            tag
+        );
+
+        // Verify it's deterministic by calling again (should return same tag)
+        let result2 = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert_eq!(result2.unwrap(), tag, "Should return same tag consistently");
+    }
+
+    #[test]
+    fn test_resolve_head_tilde_reference() {
+        // Test: Should resolve HEAD~ reference to tag on parent commit
+        let (_temp_dir, repo_path) = create_test_repo();
+
+        // First commit with tag
+        let first_commit_oid = create_commit(&repo_path, "First release");
+        create_tag(&repo_path, "v1.0.0", first_commit_oid);
+
+        // Second commit (becomes HEAD)
+        create_commit(&repo_path, "Second commit");
+
+        // Should resolve HEAD~ to the first commit's tag
+        let result = resolve_commit_to_tag(&repo_path, "HEAD~", "v*");
+        assert!(result.is_ok(), "Should resolve HEAD~ to tag");
+        assert_eq!(result.unwrap(), "v1.0.0");
+    }
+
+    #[test]
+    fn test_annotated_tag_resolution() {
+        // Test: Should resolve annotated tags (not just lightweight tags)
+        let (_temp_dir, repo_path) = create_test_repo();
+        let repo = Repository::open(&repo_path).expect("Failed to open repository");
+
+        let commit_oid = create_commit(&repo_path, "Annotated tag commit");
+        let commit = repo.find_commit(commit_oid).expect("Failed to find commit");
+        let obj = commit.as_object();
+
+        // Create an annotated tag
+        let sig =
+            Signature::now("Test User", "test@example.com").expect("Failed to create signature");
+        repo.tag("v7.0.0", obj, &sig, "Release v7.0.0", false)
+            .expect("Failed to create annotated tag");
+
+        let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
+        assert!(result.is_ok(), "Should resolve annotated tag");
+        assert_eq!(result.unwrap(), "v7.0.0");
+    }
+
+    #[test]
+    fn test_invalid_repo_path_returns_error() {
+        // Test: Invalid repository path should return error
+        let invalid_path = PathBuf::from("/nonexistent/path/to/repo");
+
+        let result = resolve_commit_to_tag(&invalid_path, "HEAD", "v*");
+        assert!(result.is_err(), "Should return error for invalid repo path");
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Failed to open git repository"),
+            "Error message should mention repository opening failure, got: {}",
+            err_msg
+        );
+    }
 }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -1158,15 +1158,12 @@ fn resolve_commit_to_tag(
         .show_commit_oid_as_fallback(false)
         .pattern(tag_pattern);
 
-    let describe_result = obj
-        .describe(&describe_options)
-        .with_context(|| {
-            format!(
-                "No tag matching pattern '{}' found for commit {}",
-                tag_pattern,
-                commit_ref
-            )
-        })?;
+    let describe_result = obj.describe(&describe_options).with_context(|| {
+        format!(
+            "No tag matching pattern '{}' found for commit {}",
+            tag_pattern, commit_ref
+        )
+    })?;
 
     // Format without any suffix (just the tag name)
     let mut format_options = git2::DescribeFormatOptions::new();
@@ -1489,7 +1486,11 @@ mod tests {
         // When searching for "v*", should only return v-prefixed tag
         let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
         assert!(result.is_ok(), "Should successfully resolve to tag");
-        assert_eq!(result.unwrap(), "v2.0.0", "Should return only v-prefixed tag");
+        assert_eq!(
+            result.unwrap(),
+            "v2.0.0",
+            "Should return only v-prefixed tag"
+        );
 
         // When searching for "cargo-fslabscli-*", should only return that tag
         let result = resolve_commit_to_tag(&repo_path, "HEAD", "cargo-fslabscli-*");
@@ -1508,7 +1509,10 @@ mod tests {
 
         // Try to find v* tags when only "latest" and "stable" exist
         let result = resolve_commit_to_tag(&repo_path, "HEAD", "v*");
-        assert!(result.is_err(), "Should return error when no tags match pattern");
+        assert!(
+            result.is_err(),
+            "Should return error when no tags match pattern"
+        );
 
         let err_msg = result.unwrap_err().to_string();
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ pub struct PackageRelatedOptions {
         alias = "pull-pull-ref"
     )]
     head_rev: String,
-    #[clap(long, env = "PULL_BASE_REF", alias = "pull-base-ref")]
+    #[clap(long, env = "PULL_BASE_SHA", alias = "pull-base-ref")]
     base_rev: Option<String>,
     #[arg(long, env, default_value = "1")]
     job_limit: usize,


### PR DESCRIPTION
fix #208 

Streamline our usage of PULL_BASE_REF and allow publishing to map commit to tag